### PR TITLE
Fix newline replacement in cwa clean_address

### DIFF
--- a/pretix_cwa/__init__.py
+++ b/pretix_cwa/__init__.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     raise RuntimeError("Please use pretix 2.7 or above to run this plugin!")
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 
 class PluginApp(PluginConfig):

--- a/pretix_cwa/generator.py
+++ b/pretix_cwa/generator.py
@@ -1,6 +1,5 @@
 import cwa_qr
 import hashlib
-import re
 from datetime import timedelta
 from django.conf import settings
 from pretix.base.models import Event, SubEvent
@@ -8,8 +7,9 @@ from pytz import UTC
 
 
 def clean_address(a):
+    a = a.replace("\r\n", ", ")
+    a = a.replace("\r", ", ")
     a = a.replace("\n", ", ")
-    a = re.sub(r"[^ A-Za-z0-9.\-,]+", "", a)
     return a
 
 


### PR DESCRIPTION
z#2390397
Fixes unwanted replacement of non-ascii characters and also fixes newline replacement